### PR TITLE
Macbook M1 芯片，构建自定义容器镜像，fc无法访问/识别

### DIFF
--- a/nodejs-express/Dockerfile
+++ b/nodejs-express/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:14.5.0-alpine3.11
+# Enforce the platform to AMD64 to prevent unsupported ARM64 images that generated on Macbook M1 chips
+FROM --platform=linux/amd64 node:14.5.0-alpine3.11
 
 # Create app directory
 WORKDIR /usr/src/app

--- a/puppeteer-pdf/Dockerfile
+++ b/puppeteer-pdf/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:10.15
+# Enforce the platform to AMD64 to prevent unsupported ARM64 images that generated on Macbook M1 chips
+FROM --platform=linux/amd64 node:10.15
 
 RUN apt-get update && apt-get install -y wget --no-install-recommends \
   && wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add - \


### PR DESCRIPTION
如钉钉沟通，由于Macbook M1 芯片构建的镜像默认是 arm64的 部署之后，函数计算无法识别，导致访问超时。

有两种方案可以解决：

1. 手动构建 amd64的镜像
2. 在dockerfile指定实用 `--platform=linux/amd64 `

该PR使用了方案2对部分Dockerfile添加了指定平台

* 添加前 M1 构建的是 arm64
    <img width="571" alt="image" src="https://user-images.githubusercontent.com/3351337/153833351-dd7484b7-4699-4628-b07b-8a8c6cacf6a4.png">

* 添加后 M1 构建的是 amd64
    <img width="905" alt="image" src="https://user-images.githubusercontent.com/3351337/153833333-72340faa-c730-4a39-9ce5-cbdc86b98237.png">


PS：对于其他镜像比如go，asp，测试无效（可能源镜像不支持指定paltform?）就未进行修改。